### PR TITLE
using cognitive_custom_subdomain for cognitive services endpoint

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,4 +1,4 @@
 locals {
   secret_expiry_date = timeadd(timestamp(), "8760h")
-  cog_service_endpoint = var.cognitive_private_link ? "https://cs${var.cognitive_account_name}${random_string.build_index.result}.cognitiveservices.azure.com/translator/text/v3.0/translate?api-version=3.0" : "https://api.cognitive.microsofttranslator.com"
+  cog_service_endpoint = var.cognitive_private_link ? "https://cs${var.cognitive_custom_subdomain}${random_string.build_index.result}.cognitiveservices.azure.com/translator/text/v3.0/translate?api-version=3.0" : "https://api.cognitive.microsofttranslator.com"
 }


### PR DESCRIPTION
* setting local variable to reflect cognitive_custom_subdomain value